### PR TITLE
Fix issue with prepared statement arguments

### DIFF
--- a/internal/protocol/parameter.go
+++ b/internal/protocol/parameter.go
@@ -101,6 +101,12 @@ func (f *ParameterFieldSet) String() string {
 }
 
 func (f *ParameterFieldSet) read(rd *bufio.Reader) {
+	// This function is likely to be called multiple times on the same prepared
+	// statement (because HANA may send PARAMETERMETADATA parts even when
+	// executing the statement), so we need to empty these slices lest they keep
+	// growing.
+	f._inputFields = f._inputFields[:0]
+	f._outputFields = f._outputFields[:0]
 	for i := 0; i < len(f.fields); i++ {
 		field := newParameterField(f.names)
 		field.read(rd)


### PR DESCRIPTION
This PR fixes an issue that caused the number of expected arguments for a prepared statement to double. Since HANA may send `PARAMETERMETADATA` parts in its response, even when executing the statement (not only when preparing it), the input/output arguments slices need to be emptied before reading the part's contents. Otherwise, the slices will keep growing and supplying the original amount of arguments will raise an "invalid number of arguments" error.