### PR TITLE
Provide column metadata for CALL statements

### DIFF
--- a/driver/driver_legacy.go
+++ b/driver/driver_legacy.go
@@ -473,6 +473,22 @@ func (r *procedureCallResult) Next(dest []driver.Value) error {
 	return nil
 }
 
+func (r *procedureCallResult) ColumnTypeDatabaseTypeName(idx int) string {
+	return r.prmFieldSet.Field(idx).TypeCode().TypeName()
+}
+
+func (r *procedureCallResult) ColumnTypeLength(idx int) (int64, bool) {
+	return r.prmFieldSet.Field(idx).TypeLength()
+}
+
+func (r *procedureCallResult) ColumnTypePrecisionScale(idx int) (int64, int64, bool) {
+	return r.prmFieldSet.Field(idx).TypePrecisionScale()
+}
+
+func (r *procedureCallResult) ColumnTypeNullable(idx int) (bool, bool) {
+	return r.prmFieldSet.Field(idx).Nullable(), true
+}
+
 func (r *procedureCallResult) tableRows(idx int) (driver.Rows, error) {
 	if idx >= len(r._tableRows) {
 		return nil, fmt.Errorf("table row index %d exceeds maximun %d", idx, len(r._tableRows)-1)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/SAP/go-hdb
 
-require golang.org/x/text v0.3.0
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.2.2
+	golang.org/x/text v0.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/protocol/parameter.go
+++ b/internal/protocol/parameter.go
@@ -101,6 +101,12 @@ func (f *ParameterFieldSet) String() string {
 }
 
 func (f *ParameterFieldSet) read(rd *bufio.Reader) {
+	// This function is likely to be called multiple times on the same prepared
+	// statement (because HANA may send PARAMETERMETADATA parts even when
+	// executing the statement), so we need to empty these slices lest they keep
+	// growing.
+	f._inputFields = f._inputFields[:0]
+	f._outputFields = f._outputFields[:0]
 	for i := 0; i < len(f.fields); i++ {
 		field := newParameterField(f.names)
 		field.read(rd)


### PR DESCRIPTION
This makes the `sql.Rows` object returned by `Query` also provide column type information for `CALL` statements with output parameters.