### PR TITLE
Fix timestamp rounding behaviour

### DIFF
--- a/internal/protocol/field.go
+++ b/internal/protocol/field.go
@@ -400,6 +400,7 @@ func writeField(wr *bufio.Writer, tc TypeCode, arg driver.NamedValue) error {
 		if !ok {
 			return fmt.Errorf("invalid argument type %T", v)
 		}
+		t = t.Round(time.Millisecond)
 		writeDate(wr, t)
 		writeTime(wr, t)
 
@@ -524,7 +525,7 @@ func writeTime(wr *bufio.Writer, t time.Time) {
 
 	wr.WriteB(byte(utc.Hour()) | 0x80)
 	wr.WriteInt8(int8(utc.Minute()))
-	millisecs := utc.Second()*1000 + utc.Round(time.Millisecond).Nanosecond()/1000000
+	millisecs := utc.Second()*1000 + utc.Nanosecond()/1000000
 	wr.WriteUint16(uint16(millisecs))
 }
 


### PR DESCRIPTION
Currently, a timestamp is rounded only when the number of milliseconds is calculated. This means that, if rounding up occurs, the carry-1 may be discarded and the timestamp will appear to have lost the fractional value.

For example: `2019-04-08 23:59:59.9999999` (7-digit precision is warranted by the [SQL Reference](https://help.sap.com/viewer/4fe29514fd584807ac9f2a04f6754767/2.0.03/en-US/3f81ccc7e35d44cbbc595c7d552c202a.html)) should become either:
1. `2019-04-08 23:59:59.999` (by truncating to milliseconds); or
1. `2019-04-09 00:00:00` (by rounding up).

The current implementation appears to intend the latter, but it mistakenly disregards the carry-1 effects by using the result of `time.Round` only for the nanoseconds, producing `2019-04-08 23:59:59`. This PR fixes this issue by rounding the timestamp before writing any of its values onto the wire.