### PR TITLE
converter: allow string type for integer and float argument types

### DIFF
--- a/driver/converter.go
+++ b/driver/converter.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"strconv"
 	"time"
 
 	p "github.com/SAP/go-hdb/internal/protocol"
@@ -128,6 +129,7 @@ func convertNvInteger(v interface{}, min, max int64) (driver.Value, error) {
 	}
 
 	rv := reflect.ValueOf(v)
+
 	switch rv.Kind() {
 
 	// bool is represented in HDB as tinyint
@@ -145,6 +147,11 @@ func convertNvInteger(v interface{}, min, max int64) (driver.Value, error) {
 			return nil, ErrIntegerOutOfRange
 		}
 		return int64(u64), nil
+	case reflect.String:
+		sInt, err := strconv.ParseInt(rv.String(), 10, 64)
+		if err == nil {
+			return sInt, nil
+		}
 	case reflect.Ptr:
 		// indirect pointers
 		if rv.IsNil() {
@@ -172,6 +179,11 @@ func convertNvFloat(v interface{}, max float64) (driver.Value, error) {
 			return nil, ErrFloatOutOfRange
 		}
 		return f64, nil
+	case reflect.String:
+		sFloat, err := strconv.ParseFloat(rv.String(), 64)
+		if err == nil {
+			return sFloat, nil
+		}
 	case reflect.Ptr:
 		// indirect pointers
 		if rv.IsNil() {

--- a/internal/protocol/parameter.go
+++ b/internal/protocol/parameter.go
@@ -101,6 +101,12 @@ func (f *ParameterFieldSet) String() string {
 }
 
 func (f *ParameterFieldSet) read(rd *bufio.Reader) {
+	// This function is likely to be called multiple times on the same prepared
+	// statement (because HANA may send PARAMETERMETADATA parts even when
+	// executing the statement), so we need to empty these slices lest they keep
+	// growing.
+	f._inputFields = f._inputFields[:0]
+	f._outputFields = f._outputFields[:0]
 	for i := 0; i < len(f.fields); i++ {
 		field := newParameterField(f.names)
 		field.read(rd)


### PR DESCRIPTION
This change allow to insert a type string for arguments types integer and float converting the string to int64 for integer and float64 for float with strconv.