### PR TITLE
Fix typo in code comments against sqlTrace in sqltrace.go

### DIFF
--- a/driver/sqltrace/sqltrace.go
+++ b/driver/sqltrace/sqltrace.go
@@ -20,7 +20,7 @@ func boolToInt64(f bool) int64 {
 }
 
 type sqlTrace struct {
-	// 64-bit alignement
+	// 64-bit alignment
 	on int64 // atomic access (0: false, 1:true)
 
 	*log.Logger


### PR DESCRIPTION
Fixed typo in code comments against sqlTrace in `sqltrace.go`