### PR TITLE
fix stored procedure call

### DIFF
--- a/internal/protocol/session.go
+++ b/internal/protocol/session.go
@@ -384,6 +384,10 @@ func (s *Session) ExecCall(pr *PrepareResult, args []interface{}) (driver.Result
 		}
 	}
 
+	if len(outPrmFields) == 0 {
+		return nil, nil
+	}
+
 	// TODO release v1.0.0 - assign output parameters
 	return nil, fmt.Errorf("not implemented yet")
 	//return driver.ResultNoRows, nil


### PR DESCRIPTION
session.ExecCall: if stored procedure does not use output params, don't return "not implemented yet" error