### PR TITLE
chore: Correct REUSE tool references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # go-hdb
 [![Go Reference](https://pkg.go.dev/badge/github.com/SAP/go-hdb/driver.svg)](https://pkg.go.dev/github.com/SAP/go-hdb/driver)
 [![Go Report Card](https://goreportcard.com/badge/github.com/SAP/go-hdb)](https://goreportcard.com/report/github.com/SAP/go-hdb)
-[![REUSE status](https://api.reuse.software/badge/git.fsfe.org/reuse/api)](https://api.reuse.software/info/git.fsfe.org/reuse/api)
+[![REUSE status](https://api.reuse.software/badge/github.com/SAP/go-hdb)](https://api.reuse.software/info/github.com/SAP/go-hdb)
 ![](https://github.com/SAP/go-hdb/workflows/build/badge.svg)
 
 Go-hdb is a native Go (golang) HANA database driver for Go's sql package. It implements the SAP HANA SQL command network protocol.
@@ -66,3 +66,7 @@ go test --tags unit
 ## Dependencies
 
 * Please see [go.mod](https://github.com/SAP/go-hdb/blob/main/go.mod).
+
+## Licensing
+
+Copyright 2014-2021 SAP SE or an SAP affiliate company and go-hdb contributors. Please see our [LICENSE](LICENSE.md) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/SAP/go-hdb).


### PR DESCRIPTION
This PR corrects the REUSE Tool links in the README.

**Notes:** 
- Please register the repository with the REUSE Tool to complete the integration (see #80 and #81)

Fixes #79