### PR TITLE
fix: session auth for on-prem hana

### DIFF
--- a/driver/internal/protocol/auth.go
+++ b/driver/internal/protocol/auth.go
@@ -47,7 +47,7 @@ func (a *Auth) String() string { return fmt.Sprintf("logonname %s", a.logonname)
 
 // AddSessionCookie adds session cookie authentication method.
 func (a *Auth) AddSessionCookie(cookie []byte, clientID string) {
-	a.methods[auth.MtSessionCookie] = auth.NewSessionCookie(cookie, clientID)
+	a.methods[auth.MtSessionCookie] = auth.NewSessionCookie(cookie, a.logonname, clientID)
 	auth.Tracef("add session cookie: cookie %v clientID %s", cookie, clientID)
 }
 

--- a/driver/internal/protocol/auth/sessioncookie.go
+++ b/driver/internal/protocol/auth/sessioncookie.go
@@ -10,13 +10,14 @@ import (
 
 // SessionCookie implements session cookie authentication.
 type SessionCookie struct {
-	cookie   []byte
-	clientID string
+	cookie    []byte
+	logonname string
+	clientID  string
 }
 
 // NewSessionCookie creates a new authSessionCookie instance.
-func NewSessionCookie(cookie []byte, clientID string) *SessionCookie {
-	return &SessionCookie{cookie: cookie, clientID: clientID}
+func NewSessionCookie(cookie []byte, logonname, clientID string) *SessionCookie {
+	return &SessionCookie{cookie: cookie, logonname: logonname, clientID: clientID}
 }
 
 func (a *SessionCookie) String() string {
@@ -32,7 +33,7 @@ func (a *SessionCookie) Order() byte { return MoSessionCookie }
 // PrepareInitReq implements the Method interface.
 func (a *SessionCookie) PrepareInitReq(prms *Prms) {
 	prms.addString(a.Typ())
-	prms.addBytes(append(a.cookie, a.clientID...)) //cookie + clientID !!!
+	prms.addBytes(append(a.cookie, a.clientID...)) // cookie + clientID !!!
 }
 
 // InitRepDecode implements the Method interface.
@@ -42,6 +43,7 @@ func (a *SessionCookie) InitRepDecode(d *Decoder) error {
 
 // PrepareFinalReq implements the Method interface.
 func (a *SessionCookie) PrepareFinalReq(prms *Prms) error {
+	prms.AddCESU8String(a.logonname)
 	prms.addString(a.Typ())
 	prms.addEmpty() // empty parameter
 	return nil


### PR DESCRIPTION
On premise hana instances require the username for session authentication. Otherwise a sql error is returned:
 `SQL Error 1033 - error while parsing protocol: invalid part found`.