### PR TITLE
add reason to bad connection error

### DIFF
--- a/driver/connection.go
+++ b/driver/connection.go
@@ -157,7 +157,7 @@ func (c *dbConn) Read(b []byte) (n int, err error) {
 retError:
 	dlog.Printf("Connection read error local address %s remote address %s: %s", c.conn.LocalAddr(), c.conn.RemoteAddr(), err)
 	c.lastError = err
-	return n, driver.ErrBadConn
+	return n, fmt.Errorf("%w: %s", driver.ErrBadConn, err)
 }
 
 // Write implements the io.Writer interface.
@@ -181,7 +181,9 @@ func (c *dbConn) Write(b []byte) (n int, err error) {
 retError:
 	dlog.Printf("Connection write error local address %s remote address %s: %s", c.conn.LocalAddr(), c.conn.RemoteAddr(), err)
 	c.lastError = err
-	return n, driver.ErrBadConn
+	// include err in the returned error to inform why the connection is bad (e.g. when the server certificate cannot
+	// be verified).
+	return n, fmt.Errorf("%w: %s", driver.ErrBadConn, err)
 }
 
 const (


### PR DESCRIPTION
Instead of raising a plain driver.ErrBadConn error, raise an error that
- wraps driver.ErrBadConn.
- provides information why the connection is bad (by adding the text of the underlying error).

This is helpful in case of issues with server certificate validation. Instead of just
```
driver: bad connection
```
the error is then
```
driver: bad connection: x509: certificate signed by unknown authority
driver: bad connection: x509: certificate relies on legacy Common Name field, use SANs instead
```