### PR TITLE
Fix go-critic issues

### DIFF
--- a/cmd/sniffer/sniffer.go
+++ b/cmd/sniffer/sniffer.go
@@ -24,7 +24,8 @@ func main() {
 	for {
 		conn, err := l.Accept()
 		if err != nil {
-			log.Fatal(err)
+			log.Print(err)
+			return
 		}
 
 		go handler(conn, dbAddr)

--- a/driver/bulk_test.go
+++ b/driver/bulk_test.go
@@ -145,12 +145,12 @@ func testBulkBlob(conn *sql.Conn, t *testing.T) {
 
 	tmpTableName := RandomIdentifier("#tmpTable")
 
-	//keep connection / hdb session for using local temporary tables
+	// keep connection / hdb session for using local temporary tables
 	tx, err := conn.BeginTx(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer tx.Rollback() //cleanup
+	defer tx.Rollback() // cleanup
 
 	if _, err := tx.Exec(fmt.Sprintf("create local temporary table %s (i integer, b blob)", tmpTableName)); err != nil {
 		t.Fatalf("create table failed: %s", err)
@@ -269,7 +269,7 @@ func testBulkGeo(conn *sql.Conn, t *testing.T) {
 		if j != i {
 			t.Fatalf("value %d - expected %d", j, i)
 		}
-		//t.Logf("value: %[1]v%[1]s", b)
+		// t.Logf("value: %[1]v%[1]s", b)
 		i++
 	}
 	if err := rows.Err(); err != nil {

--- a/driver/connection.go
+++ b/driver/connection.go
@@ -1168,8 +1168,7 @@ func (c *conn) _dbConnectInfo(databaseName string) (*DBConnectInfo, error) {
 	}
 
 	if err := c.pr.IterateParts(func(ph *p.PartHeader) {
-		switch ph.PartKind {
-		case p.PkDBConnectInfo:
+		if ph.PartKind == p.PkDBConnectInfo {
 			c.pr.Read(&ci)
 		}
 	}); err != nil {

--- a/driver/connection.go
+++ b/driver/connection.go
@@ -101,7 +101,7 @@ func (c *dbConn) close() error { return c.conn.Close() }
 // Read implements the io.Reader interface.
 func (c *dbConn) Read(b []byte) (n int, err error) {
 	var start time.Time
-	//set timeout
+	// set timeout
 	if err = c.conn.SetReadDeadline(c.deadline()); err != nil {
 		goto retError
 	}
@@ -121,7 +121,7 @@ retError:
 // Write implements the io.Writer interface.
 func (c *dbConn) Write(b []byte) (n int, err error) {
 	var start time.Time
-	//set timeout
+	// set timeout
 	if err = c.conn.SetWriteDeadline(c.deadline()); err != nil {
 		goto retError
 	}
@@ -544,7 +544,7 @@ var callStmt = regexp.MustCompile(`(?i)^\s*call\s+.*`) // sql statemant beginnin
 // QueryContext implements the driver.QueryerContext interface.
 func (c *conn) QueryContext(ctx context.Context, query string, nvargs []driver.NamedValue) (rows driver.Rows, err error) {
 	if len(nvargs) != 0 {
-		return nil, driver.ErrSkip //fast path not possible (prepare needed)
+		return nil, driver.ErrSkip // fast path not possible (prepare needed)
 	}
 
 	if err := c.tryLock(lrNestedQuery); err != nil {
@@ -596,7 +596,7 @@ func (c *conn) QueryContext(ctx context.Context, query string, nvargs []driver.N
 // ExecContext implements the driver.ExecerContext interface.
 func (c *conn) ExecContext(ctx context.Context, query string, nvargs []driver.NamedValue) (r driver.Result, err error) {
 	if len(nvargs) != 0 {
-		return nil, driver.ErrSkip //fast path not possible (prepare needed)
+		return nil, driver.ErrSkip // fast path not possible (prepare needed)
 	}
 
 	if err := c.tryLock(0); err != nil {
@@ -696,7 +696,7 @@ func (c *conn) addSQLTimeValue(start time.Time, k int) {
 	c.metrics.chMsg <- sqlTimeMsg{idx: k, d: time.Since(start)}
 }
 
-//transaction
+// transaction
 
 // check if tx implements all required interfaces
 var (
@@ -1176,7 +1176,7 @@ func (c *conn) _dbConnectInfo(databaseName string) (*DBConnectInfo, error) {
 		return nil, err
 	}
 
-	host, _ := ci[p.CiHost].(string) //check existencs and covert to string
+	host, _ := ci[p.CiHost].(string) // check existencs and covert to string
 	port, _ := ci[p.CiPort].(int32)  // check existence and convert to integer
 	isConnected, _ := ci[p.CiIsConnected].(bool)
 
@@ -1222,7 +1222,7 @@ func (c *conn) _authenticate(auth *p.Auth, applicationName string, dfv int, loca
 	if err != nil {
 		return 0, nil, err
 	}
-	//co := c.defaultClientOptions()
+	// co := c.defaultClientOptions()
 
 	co := func() p.Options[p.ConnectOption] {
 		co := p.Options[p.ConnectOption]{

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -58,8 +58,8 @@ func testInsertByQuery(db *sql.DB, t *testing.T) {
 }
 
 func testHDBError(db *sql.DB, t *testing.T) {
-	//select from not existing table with different table name length
-	//to check if padding, etc works (see hint in protocol.error.Read(...))
+	// select from not existing table with different table name length
+	// to check if padding, etc works (see hint in protocol.error.Read(...))
 	for i := 0; i < 9; i++ {
 		_, err := db.Query(fmt.Sprintf("select * from %s", strings.Repeat("x", i+1)))
 		if err == nil {

--- a/driver/example_bulk_test.go
+++ b/driver/example_bulk_test.go
@@ -26,13 +26,15 @@ func Example_bulkInsert() {
 
 	// Create table.
 	if _, err := db.Exec(fmt.Sprintf("create table %s (i integer, f double)", tableName)); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	// Prepare statement.
 	stmt, err := db.PrepareContext(context.Background(), fmt.Sprintf("insert into %s values (?, ?)", tableName))
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 	defer stmt.Close()
 
@@ -42,7 +44,8 @@ func Example_bulkInsert() {
 		args[i*2], args[i*2+1] = i, float64(i)
 	}
 	if _, err := stmt.Exec(args...); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	// Bulk insert via function.
@@ -55,18 +58,21 @@ func Example_bulkInsert() {
 		i++
 		return nil
 	}); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	// Select number of inserted rows.
 	if err := db.QueryRow(fmt.Sprintf("select count(*) from %s", tableName)).Scan(&numRow); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 	fmt.Print(numRow)
 
 	// Drop table.
 	if _, err := db.Exec(fmt.Sprintf("drop table %s", tableName)); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	// output: 2000

--- a/driver/example_call_test.go
+++ b/driver/example_call_test.go
@@ -26,13 +26,15 @@ end
 	procedure := RandomIdentifier("procOut_")
 
 	if _, err := db.Exec(fmt.Sprintf(procOut, procedure)); err != nil { // Create stored procedure.
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	var out string
 
 	if _, err := db.Exec(fmt.Sprintf("call %s(?)", procedure), sql.Named("MESSAGE", sql.Out{Dest: &out})); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	fmt.Print(out)
@@ -66,11 +68,13 @@ end
 	procedure := RandomIdentifier("ProcTable_")
 
 	if _, err := db.Exec(fmt.Sprintf("create type %s as table (x nvarchar(256))", tableType)); err != nil { // Create table type.
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	if _, err := db.Exec(fmt.Sprintf(procTable, procedure, tableType)); err != nil { // Create stored procedure.
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	var tableRows sql.Rows // Scan variable of table output parameter.
@@ -78,25 +82,29 @@ end
 	// Call stored procedure via prepare.
 	stmt, err := db.Prepare(fmt.Sprintf("call %s(?)", procedure))
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 	defer stmt.Close()
 
 	if _, err := stmt.Exec(sql.Named("T", sql.Out{Dest: &tableRows})); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	for tableRows.Next() {
 		var x string
 
 		if err := tableRows.Scan(&x); err != nil {
-			log.Fatal(err)
+			log.Print(err)
+			return
 		}
 
 		fmt.Println(x)
 	}
 	if err := tableRows.Err(); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	// output: Hello, 世界

--- a/driver/example_conn_test.go
+++ b/driver/example_conn_test.go
@@ -19,7 +19,8 @@ func ExampleConn_HDBVersion() {
 	// Grab connection.
 	conn, err := db.Conn(context.Background())
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 	defer conn.Close()
 
@@ -39,7 +40,8 @@ func ExampleConn_DBConnectInfo() {
 	// Grab connection.
 	conn, err := db.Conn(context.Background())
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 	defer conn.Close()
 
@@ -52,7 +54,8 @@ func ExampleConn_DBConnectInfo() {
 		log.Printf("db connect info: %s", ci)
 		return nil
 	}); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 	// output:
 }

--- a/driver/example_connector_test.go
+++ b/driver/example_connector_test.go
@@ -31,7 +31,8 @@ func ExampleNewDSNConnector() {
 	defer db.Close()
 
 	if err := db.Ping(); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 	// output:
 }
@@ -93,7 +94,8 @@ func ExampleNewBasicAuthConnector() {
 	defer db.Close()
 
 	if err := db.Ping(); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 	// output:
 }
@@ -131,7 +133,8 @@ func ExampleNewX509AuthConnectorByFiles() {
 	defer db.Close()
 
 	if err := db.Ping(); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 	// output:
 }
@@ -165,7 +168,8 @@ func ExampleNewJWTAuthConnector() {
 	defer db.Close()
 
 	if err := db.Ping(); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 	// output:
 }

--- a/driver/example_decimal_test.go
+++ b/driver/example_decimal_test.go
@@ -23,20 +23,23 @@ func ExampleDecimal() {
 	tableName := driver.RandomIdentifier("table_")
 
 	if _, err := db.Exec(fmt.Sprintf("create table %s (x decimal)", tableName)); err != nil { // Create table with decimal attribute.
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	// Decimal values are represented in Go as big.Rat.
 	in := (*driver.Decimal)(big.NewRat(1, 1)) // Create *big.Rat and cast to Decimal.
 
 	if _, err := db.Exec(fmt.Sprintf("insert into %s values(?)", tableName), in); err != nil { // Insert record.
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	var out driver.Decimal // Declare scan variable.
 
 	if err := db.QueryRow(fmt.Sprintf("select * from %s", tableName)).Scan(&out); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	fmt.Printf("Decimal value: %s", (*big.Rat)(&out).String()) // Cast scan variable to *big.Rat to use *big.Rat methods.

--- a/driver/example_dsn_test.go
+++ b/driver/example_dsn_test.go
@@ -27,6 +27,7 @@ func ExampleDSN() {
 	defer db.Close()
 
 	if err := db.Ping(); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 }

--- a/driver/example_error_test.go
+++ b/driver/example_error_test.go
@@ -34,7 +34,8 @@ func ExampleError() {
 			case errCodeInvalidTableName:
 				fmt.Print("invalid table name")
 			default:
-				log.Fatalf("code %d text %s", dbError.Code(), dbError.Text())
+				log.Printf("code %d text %s", dbError.Code(), dbError.Text())
+				return
 			}
 		}
 	}

--- a/driver/example_lob_test.go
+++ b/driver/example_lob_test.go
@@ -33,7 +33,8 @@ func ExampleLob_read() {
 	lob.SetWriter(b) // SetWriter sets the io.Writer object, to which the database content of the lob field is written.
 
 	if err := db.QueryRow("select * from test").Scan(lob); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 }
 
@@ -51,31 +52,36 @@ func ExampleLob_write() {
 
 	db, err := sql.Open("hdb", "hdb://user:password@host:port")
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 	defer db.Close()
 
 	tx, err := db.Begin() // Start Transaction to avoid database error: SQL Error 596 - LOB streaming is not permitted in auto-commit mode.
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	stmt, err := tx.Prepare("insert into test values(?)")
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	lob := new(driver.Lob)
 	lob.SetReader(file) // SetReader sets the io.Reader object, which content is written to the database lob field.
 
 	if _, err := stmt.Exec(lob); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	stmt.Close()
 
 	if err := tx.Commit(); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 }
 
@@ -99,18 +105,21 @@ func ExampleLob_pipe() {
 
 	tx, err := db.Begin() // Start Transaction to avoid database error: SQL Error 596 - LOB streaming is not permitted in auto-commit mode.
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	// Create table.
 	table := driver.RandomIdentifier("fileLob")
 	if _, err := tx.Exec(fmt.Sprintf("create table %s (file nclob)", table)); err != nil {
-		log.Fatalf("create table failed: %s", err)
+		log.Printf("create table failed: %s", err)
+		return
 	}
 
 	stmt, err := tx.Prepare(fmt.Sprintf("insert into %s values (?)", table))
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	lob := &driver.Lob{} // Lob field.
@@ -136,14 +145,17 @@ func ExampleLob_pipe() {
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		if _, err := pipeWriter.Write(scanner.Bytes()); err != nil {
-			log.Fatal(err)
+			log.Print(err)
+			return
 		}
 		if _, err := pipeWriter.Write([]byte{'\n'}); err != nil { // Write nl which was stripped off by scanner.
-			log.Fatal(err)
+			log.Print(err)
+			return
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 	// Close pipeWriter (end insert into db).
 	pipeWriter.Close()
@@ -153,7 +165,8 @@ func ExampleLob_pipe() {
 	stmt.Close()
 
 	if err := tx.Commit(); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	pipeReader, pipeWriter = io.Pipe() // Create pipe for reading Lob.
@@ -177,7 +190,8 @@ func ExampleLob_pipe() {
 		// Do something with scan result.
 	}
 	if err := scanner.Err(); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 	pipeReader.Close()
 

--- a/driver/example_scanlobbytes_test.go
+++ b/driver/example_scanlobbytes_test.go
@@ -27,27 +27,32 @@ func ExampleScanLobBytes() {
 	table := driver.RandomIdentifier("lob_")
 
 	if _, err := db.Exec(fmt.Sprintf("create table %s (b blob)", table)); err != nil {
-		log.Fatalf("create table failed: %s", err)
+		log.Printf("create table failed: %s", err)
+		return
 	}
 
 	tx, err := db.Begin() // Start Transaction to avoid database error: SQL Error 596 - LOB streaming is not permitted in auto-commit mode.
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	// Lob content can be written using a byte slice.
 	_, err = tx.ExecContext(context.Background(), fmt.Sprintf("insert into %s values (?)", table), []byte("scan lob bytes"))
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	if err := tx.Commit(); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	var arg BytesLob
 	if err := db.QueryRowContext(context.Background(), fmt.Sprintf("select * from %s", table)).Scan(&arg); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 	fmt.Println(string(arg))
 	// output: scan lob bytes

--- a/driver/example_scanlobstring_test.go
+++ b/driver/example_scanlobstring_test.go
@@ -27,27 +27,32 @@ func ExampleScanLobString() {
 	table := driver.RandomIdentifier("lob_")
 
 	if _, err := db.Exec(fmt.Sprintf("create table %s (n nclob)", table)); err != nil {
-		log.Fatalf("create table failed: %s", err)
+		log.Printf("create table failed: %s", err)
+		return
 	}
 
 	tx, err := db.Begin() // Start Transaction to avoid database error: SQL Error 596 - LOB streaming is not permitted in auto-commit mode.
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	// Lob content can be written using a string.
 	_, err = tx.ExecContext(context.Background(), fmt.Sprintf("insert into %s values (?)", table), "scan lob string")
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	if err := tx.Commit(); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	var arg StringLob
 	if err := db.QueryRowContext(context.Background(), fmt.Sprintf("select * from %s", table)).Scan(&arg); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 	fmt.Println(arg)
 	// output: scan lob string

--- a/driver/example_scanlobwriter_test.go
+++ b/driver/example_scanlobwriter_test.go
@@ -33,27 +33,32 @@ func ExampleScanLobWriter() {
 	table := driver.RandomIdentifier("lob_")
 
 	if _, err := db.Exec(fmt.Sprintf("create table %s (n nclob)", table)); err != nil {
-		log.Fatalf("create table failed: %s", err)
+		log.Printf("create table failed: %s", err)
+		return
 	}
 
 	tx, err := db.Begin() // Start Transaction to avoid database error: SQL Error 596 - LOB streaming is not permitted in auto-commit mode.
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	// Lob content can be written using a string.
 	_, err = tx.ExecContext(context.Background(), fmt.Sprintf("insert into %s values (?)", table), "scan lob writer")
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	if err := tx.Commit(); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	var arg WriterLob
 	if err := db.QueryRowContext(context.Background(), fmt.Sprintf("select * from %s", table)).Scan(&arg); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 	fmt.Println(string(arg))
 	// output: scan lob writer

--- a/driver/example_test.go
+++ b/driver/example_test.go
@@ -21,6 +21,7 @@ func Example() {
 	defer db.Close()
 
 	if err := db.Ping(); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 }

--- a/driver/internal/protocol/encoding/decode.go
+++ b/driver/internal/protocol/encoding/decode.go
@@ -211,7 +211,7 @@ func (d *Decoder) Decimal() (*big.Int, int, error) { // m, exp
 		return nil, 0, nil
 	}
 
-	if (bs[15] & 0x70) == 0x70 { //null value (bit 4,5,6 set)
+	if (bs[15] & 0x70) == 0x70 { // null value (bit 4,5,6 set)
 		return nil, 0, nil
 	}
 
@@ -225,13 +225,13 @@ func (d *Decoder) Decimal() (*big.Int, int, error) { // m, exp
 	// b14 := b[14]  // save b[14]
 	bs[14] &= 0x01 // keep the mantissa bit (rest: sign and exp)
 
-	//most significand byte
+	// most significant byte
 	msb := 14
 	for msb > 0 && bs[msb] == 0 {
 		msb--
 	}
 
-	//calc number of words
+	// calc number of words
 	numWords := (msb / _S) + 1
 	ws := make([]big.Word, numWords)
 
@@ -257,13 +257,13 @@ func (d *Decoder) Fixed(size int) *big.Int { // m, exp
 
 	neg := (bs[size-1] & 0x80) != 0 // is negative number (2s complement)
 
-	//most significand byte
+	// most significand byte
 	msb := size - 1
 	for msb > 0 && bs[msb] == 0 {
 		msb--
 	}
 
-	//calc number of words
+	// calc number of words
 	numWords := (msb / _S) + 1
 	ws := make([]big.Word, numWords)
 
@@ -309,7 +309,7 @@ func (d *Decoder) CESU8Bytes(size int) ([]byte, error) {
 
 // varFieldInd decodes a variable field indicator.
 func (d *Decoder) varFieldInd() (n, size int, null bool) {
-	ind := d.Byte() //length indicator
+	ind := d.Byte() // length indicator
 	switch {
 	default:
 		return 1, 0, false

--- a/driver/internal/protocol/error.go
+++ b/driver/internal/protocol/error.go
@@ -98,7 +98,7 @@ func (e *HdbError) IsFatal() bool { return e.errorLevel == errorLevelFatalError 
 // HdbErrors represent the collection of errors return by the server.
 type HdbErrors struct {
 	errs []*HdbError
-	//numArg int
+	// numArg int
 	idx int
 }
 

--- a/driver/internal/protocol/fieldtype.go
+++ b/driver/internal/protocol/fieldtype.go
@@ -482,7 +482,7 @@ func asTime(v any) time.Time {
 	if !ok {
 		panic("invalid time value") // should never happen
 	}
-	//store in utc
+	// store in utc
 	return t.UTC()
 }
 
@@ -644,25 +644,25 @@ func (_integerType) decodePrm(d *encoding.Decoder) (any, error) { return int64(d
 func (_bigintType) decodePrm(d *encoding.Decoder) (any, error)  { return d.Int64(), nil }
 
 func (ft _tinyintType) decodeRes(d *encoding.Decoder) (any, error) {
-	if !d.Bool() { //null value
+	if !d.Bool() { // null value
 		return nil, nil
 	}
 	return ft.decodePrm(d)
 }
 func (ft _smallintType) decodeRes(d *encoding.Decoder) (any, error) {
-	if !d.Bool() { //null value
+	if !d.Bool() { // null value
 		return nil, nil
 	}
 	return ft.decodePrm(d)
 }
 func (ft _integerType) decodeRes(d *encoding.Decoder) (any, error) {
-	if !d.Bool() { //null value
+	if !d.Bool() { // null value
 		return nil, nil
 	}
 	return ft.decodePrm(d)
 }
 func (ft _bigintType) decodeRes(d *encoding.Decoder) (any, error) {
-	if !d.Bool() { //null value
+	if !d.Bool() { // null value
 		return nil, nil
 	}
 	return ft.decodePrm(d)
@@ -714,7 +714,7 @@ func (_timestampType) decodeRes(d *encoding.Decoder) (any, error) {
 // day is 1 byte
 func decodeDate(d *encoding.Decoder) (int, time.Month, int, bool) {
 	year := d.Uint16()
-	null := ((year & 0x8000) == 0) //null value
+	null := ((year & 0x8000) == 0) // null value
 	year &= 0x3fff
 	month := d.Int8()
 	month++
@@ -724,7 +724,7 @@ func decodeDate(d *encoding.Decoder) (int, time.Month, int, bool) {
 
 func decodeTime(d *encoding.Decoder) (int, int, int, int, bool) {
 	hour := d.Byte()
-	null := (hour & 0x80) == 0 //null value
+	null := (hour & 0x80) == 0 // null value
 	hour &= 0x7f
 	min := d.Int8()
 	msec := d.Uint16()
@@ -777,19 +777,19 @@ func (_decimalType) decodeRes(d *encoding.Decoder) (any, error) {
 }
 
 func (ft _fixed8Type) decodeRes(d *encoding.Decoder) (any, error) {
-	if !d.Bool() { //null value
+	if !d.Bool() { // null value
 		return nil, nil
 	}
 	return decodeFixed(d, encoding.Fixed8FieldSize, ft.prec, ft.scale)
 }
 func (ft _fixed12Type) decodeRes(d *encoding.Decoder) (any, error) {
-	if !d.Bool() { //null value
+	if !d.Bool() { // null value
 		return nil, nil
 	}
 	return decodeFixed(d, encoding.Fixed12FieldSize, ft.prec, ft.scale)
 }
 func (ft _fixed16Type) decodeRes(d *encoding.Decoder) (any, error) {
-	if !d.Bool() { //null value
+	if !d.Bool() { // null value
 		return nil, nil
 	}
 	return decodeFixed(d, encoding.Fixed16FieldSize, ft.prec, ft.scale)

--- a/driver/internal/protocol/headers.go
+++ b/driver/internal/protocol/headers.go
@@ -104,7 +104,7 @@ type segmentHeader struct {
 func (h *segmentHeader) String() string {
 	switch h.segmentKind {
 
-	default: //error
+	default: // error
 		return fmt.Sprintf(
 			"segmentLength %d segmentOfs %d noOfParts %d, segmentNo %d segmentKind %s",
 			h.segmentLength,
@@ -148,19 +148,19 @@ func (h *segmentHeader) encode(enc *encoding.Encoder) error {
 
 	switch h.segmentKind {
 
-	default: //error
-		enc.Zeroes(11) //segmentHeaderLength
+	default: // error
+		enc.Zeroes(11) // segmentHeaderLength
 
 	case skRequest:
 		enc.Int8(int8(h.messageType))
 		enc.Bool(h.commit)
 		enc.Int8(int8(h.commandOptions))
-		enc.Zeroes(8) //segmentHeaderSize
+		enc.Zeroes(8) // segmentHeaderSize
 
 	case skReply:
-		enc.Zeroes(1) //reserved
+		enc.Zeroes(1) // reserved
 		enc.Int16(int16(h.functionCode))
-		enc.Zeroes(8) //segmentHeaderSize
+		enc.Zeroes(8) // segmentHeaderSize
 	}
 	return nil
 }
@@ -175,19 +175,19 @@ func (h *segmentHeader) decode(dec *encoding.Decoder) error {
 
 	switch h.segmentKind {
 
-	default: //error
-		dec.Skip(11) //segmentHeaderLength
+	default: // error
+		dec.Skip(11) // segmentHeaderLength
 
 	case skRequest:
 		h.messageType = MessageType(dec.Int8())
 		h.commit = dec.Bool()
 		h.commandOptions = commandOptions(dec.Int8())
-		dec.Skip(8) //segmentHeaderLength
+		dec.Skip(8) // segmentHeaderLength
 
 	case skReply:
-		dec.Skip(1) //reserved
+		dec.Skip(1) // reserved
 		h.functionCode = FunctionCode(dec.Int16())
-		dec.Skip(8) //segmentHeaderLength
+		dec.Skip(8) // segmentHeaderLength
 	}
 	return dec.Error()
 }
@@ -285,7 +285,7 @@ func (h *PartHeader) encode(enc *encoding.Encoder) error {
 	enc.Int32(h.bigArgumentCount)
 	enc.Int32(h.bufferLength)
 	enc.Int32(h.bufferSize)
-	//no filler
+	// no filler
 	return nil
 }
 

--- a/driver/internal/protocol/init.go
+++ b/driver/internal/protocol/init.go
@@ -45,12 +45,12 @@ func (r *initRequest) String() string {
 }
 
 func (r *initRequest) decode(dec *encoding.Decoder) error {
-	dec.Skip(initRequestFillerSize) //filler
+	dec.Skip(initRequestFillerSize) // filler
 	r.product.major = dec.Int8()
 	r.product.minor = dec.Int16()
 	r.protocol.major = dec.Int8()
 	r.protocol.minor = dec.Int16()
-	dec.Skip(1) //reserved filler
+	dec.Skip(1) // reserved filler
 	r.numOptions = dec.Int8()
 
 	switch r.numOptions {
@@ -108,6 +108,6 @@ func (r *initReply) decode(dec *encoding.Decoder) error {
 	r.product.minor = dec.Int16()
 	r.protocol.major = dec.Int8()
 	r.protocol.minor = dec.Int16()
-	dec.Skip(2) //commitInitReplySize
+	dec.Skip(2) // commitInitReplySize
 	return dec.Error()
 }

--- a/driver/internal/protocol/lob.go
+++ b/driver/internal/protocol/lob.go
@@ -184,7 +184,7 @@ func (d *WriteLobDescr) FetchNext(chunkSize int) error {
 		return err
 	}
 	d.Opt = d.LobInDescr.opt
-	d.ofs = -1 //offset (-1 := append)
+	d.ofs = -1 // offset (-1 := append)
 	d.b = d.LobInDescr.b
 	return nil
 }
@@ -309,7 +309,7 @@ func (r *ReadLobRequest) decode(dec *encoding.Decoder, ph *PartHeader) error {
 
 func (r *ReadLobRequest) encode(enc *encoding.Encoder) error {
 	enc.Uint64(uint64(r.ID))
-	enc.Int64(r.Ofs + 1) //1-based
+	enc.Int64(r.Ofs + 1) // 1-based
 	enc.Int32(r.ChunkSize)
 	enc.Zeroes(4)
 	return nil

--- a/driver/internal/protocol/optionsparts.go
+++ b/driver/internal/protocol/optionsparts.go
@@ -69,7 +69,7 @@ func (ops Options[K]) String() string {
 }
 
 func (ops Options[K]) size() int {
-	size := 2 * len(ops) //option + type
+	size := 2 * len(ops) // option + type
 	for _, v := range ops {
 		ot := getOptType(v)
 		size += ot.size(v)

--- a/driver/internal/protocol/optiontype.go
+++ b/driver/internal/protocol/optiontype.go
@@ -65,8 +65,8 @@ func (_optTinyintType) size(any) int   { return encoding.TinyintFieldSize }
 func (_optIntegerType) size(any) int   { return encoding.IntegerFieldSize }
 func (_optBigintType) size(any) int    { return encoding.BigintFieldSize }
 func (_optDoubleType) size(any) int    { return encoding.DoubleFieldSize }
-func (_optStringType) size(v any) int  { return 2 + len(v.(string)) } //length int16 + string length
-func (_optBstringType) size(v any) int { return 2 + len(v.([]byte)) } //length int16 + bytes length
+func (_optStringType) size(v any) int  { return 2 + len(v.(string)) } // length int16 + string length
+func (_optBstringType) size(v any) int { return 2 + len(v.([]byte)) } // length int16 + bytes length
 
 func (_optBooleanType) encode(e *encoding.Encoder, v any) { e.Bool(v.(bool)) }
 func (_optTinyintType) encode(e *encoding.Encoder, v any) { e.Int8(v.(int8)) }

--- a/driver/internal/protocol/parameter.go
+++ b/driver/internal/protocol/parameter.go
@@ -163,11 +163,11 @@ func (f *ParameterField) decode(dec *encoding.Decoder) {
 	f.parameterOptions = parameterOptions(dec.Int8())
 	f.tc = typeCode(dec.Int8())
 	f.mode = ParameterMode(dec.Int8())
-	dec.Skip(1) //filler
+	dec.Skip(1) // filler
 	f.ofs = int(dec.Uint32())
 	f.length = dec.Int16()
 	f.fraction = dec.Int16()
-	dec.Skip(4) //filler
+	dec.Skip(4) // filler
 
 	f.names.insert(uint32(f.ofs))
 
@@ -284,7 +284,7 @@ func (p *InputParameters) numArg() int {
 
 func (p *InputParameters) decode(dec *encoding.Decoder, ph *PartHeader) error {
 	// TODO Sniffer
-	//return fmt.Errorf("not implemented")
+	// return fmt.Errorf("not implemented")
 	return nil
 }
 
@@ -296,7 +296,7 @@ func (p *InputParameters) encode(enc *encoding.Encoder) error {
 
 	for i := 0; i < len(p.nvargs)/numColumns; i++ { // row-by-row
 		for j := 0; j < numColumns; j++ {
-			//mass insert
+			// mass insert
 			f := p.InputFields[j]
 			if err := f.encodePrm(enc, p.nvargs[i*numColumns+j].Value); err != nil {
 				return err

--- a/driver/internal/protocol/protocol.go
+++ b/driver/internal/protocol/protocol.go
@@ -361,7 +361,7 @@ func (w *Writer) Write(sessionID int64, messageType MessageType, commit bool, wr
 
 	numWriters := len(writers)
 	partSize := make([]int, numWriters)
-	size := int64(segmentHeaderSize + numWriters*partHeaderSize) //int64 to hold MaxUInt32 in 32bit OS
+	size := int64(segmentHeaderSize + numWriters*partHeaderSize) // int64 to hold MaxUInt32 in 32bit OS
 
 	for i, part := range writers {
 		s := part.size()

--- a/driver/internal/protocol/result.go
+++ b/driver/internal/protocol/result.go
@@ -111,7 +111,7 @@ func (f *ResultField) decode(dec *encoding.Decoder) {
 	f.tc = typeCode(dec.Int8())
 	f.fraction = dec.Int16()
 	f.length = dec.Int16()
-	dec.Skip(2) //filler
+	dec.Skip(2) // filler
 	f.tableNameOfs = dec.Uint32()
 	f.schemaNameOfs = dec.Uint32()
 	f.columnNameOfs = dec.Uint32()

--- a/driver/lob_test.go
+++ b/driver/lob_test.go
@@ -4,7 +4,6 @@
 package driver
 
 import (
-	//"bytes"
 	"bytes"
 	"context"
 	"crypto/rand"

--- a/driver/result.go
+++ b/driver/result.go
@@ -129,7 +129,7 @@ func (qr *queryResult) Next(dest []driver.Value) error {
 			return io.EOF
 		}
 		if err := qr.conn._fetchNext(qr); err != nil {
-			qr.lastErr = err //fieldValues and attrs are nil
+			qr.lastErr = err // fieldValues and attrs are nil
 			return err
 		}
 		if qr.numRow() == 0 {

--- a/driver/sniffer.go
+++ b/driver/sniffer.go
@@ -26,10 +26,10 @@ type Sniffer struct {
 	conn   net.Conn
 	dbConn net.Conn
 
-	//client
+	// client
 	clRd *bufio.Reader
 	clWr *bufio.Writer
-	//database
+	// database
 	dbRd *bufio.Reader
 	dbWr *bufio.Writer
 
@@ -42,8 +42,8 @@ type Sniffer struct {
 // is listening for hdb protocol calls. The dbAddr is the hdb host port address in "host:port" format.
 func NewSniffer(conn net.Conn, dbConn net.Conn) *Sniffer {
 
-	//TODO - review setting values here
-	//protocolTraceFlag.Set("true")
+	// TODO - review setting values here
+	// protocolTraceFlag.Set("true")
 
 	s := &Sniffer{
 		conn:   conn,
@@ -54,9 +54,9 @@ func NewSniffer(conn net.Conn, dbConn net.Conn) *Sniffer {
 		dbWr: bufio.NewWriter(dbConn),
 	}
 
-	//read from client connection and write to db buffer
+	// read from client connection and write to db buffer
 	s.clRd = bufio.NewReader(io.TeeReader(conn, s.dbWr))
-	//read from db and write to client connection buffer
+	// read from db and write to client connection buffer
 	s.dbRd = bufio.NewReader(io.TeeReader(dbConn, s.clWr))
 
 	s.upRd = newSniffUpReader(s.clRd)
@@ -84,16 +84,16 @@ func (s *Sniffer) Run() error {
 	}
 
 	for {
-		//up stream
+		// up stream
 		if err := s.upRd.readMsg(); err != nil {
 			return err // err == io.EOF: connection closed by client
 		}
 		if err := s.dbWr.Flush(); err != nil {
 			return err
 		}
-		//down stream
+		// down stream
 		if err := s.downRd.readMsg(); err != nil {
-			if _, ok := err.(*p.HdbErrors); !ok { //if hdbErrors continue
+			if _, ok := err.(*p.HdbErrors); !ok { // if hdbErrors continue
 				return err
 			}
 		}
@@ -189,8 +189,8 @@ func newSniffDownReader(rd *bufio.Reader) *sniffDownReader {
 
 func (r *sniffDownReader) readMsg() error {
 	var stmtID uint64
-	//resMeta := &resultMetadata{}
-	//prmMeta := &parameterMetadata{}
+	// resMeta := &resultMetadata{}
+	// prmMeta := &parameterMetadata{}
 
 	if err := r.pr.IterateParts(func(ph *p.PartHeader) {
 		switch ph.PartKind {

--- a/driver/tx_test.go
+++ b/driver/tx_test.go
@@ -28,12 +28,12 @@ func testTransactionCommit(db *sql.DB, t *testing.T) {
 	}
 	defer tx2.Rollback()
 
-	//insert record in transaction 1
+	// insert record in transaction 1
 	if _, err := tx1.Exec(fmt.Sprintf("insert into %s values(42)", table)); err != nil {
 		t.Fatal(err)
 	}
 
-	//count records in transaction 1
+	// count records in transaction 1
 	i := 0
 	if err := tx1.QueryRow(fmt.Sprintf("select count(*) from %s", table)).Scan(&i); err != nil {
 		t.Fatal(err)
@@ -42,7 +42,7 @@ func testTransactionCommit(db *sql.DB, t *testing.T) {
 		t.Fatal(fmt.Errorf("tx1: invalid number of records %d - 1 expected", i))
 	}
 
-	//count records in transaction 2 - isolation level 'read committed'' (default) expected, so no record should be there
+	// count records in transaction 2 - isolation level 'read committed'' (default) expected, so no record should be there
 	if err := tx2.QueryRow(fmt.Sprintf("select count(*) from %s", table)).Scan(&i); err != nil {
 		t.Fatal(err)
 	}
@@ -50,12 +50,12 @@ func testTransactionCommit(db *sql.DB, t *testing.T) {
 		t.Fatal(fmt.Errorf("tx2: invalid number of records %d - 0 expected", i))
 	}
 
-	//commit insert
+	// commit insert
 	if err := tx1.Commit(); err != nil {
 		t.Fatal(err)
 	}
 
-	//in isolation level 'read commited' (default) record should be visible now
+	// in isolation level 'read commited' (default) record should be visible now
 	if err := tx2.QueryRow(fmt.Sprintf("select count(*) from %s", table)).Scan(&i); err != nil {
 		t.Fatal(err)
 	}
@@ -75,12 +75,12 @@ func testTransactionRollback(db *sql.DB, t *testing.T) {
 		t.Fatal(err)
 	}
 
-	//insert record
+	// insert record
 	if _, err := tx.Exec(fmt.Sprintf("insert into %s values(42)", table)); err != nil {
 		t.Fatal(err)
 	}
 
-	//count records
+	// count records
 	i := 0
 	if err := tx.QueryRow(fmt.Sprintf("select count(*) from %s", table)).Scan(&i); err != nil {
 		t.Fatal(err)
@@ -89,19 +89,19 @@ func testTransactionRollback(db *sql.DB, t *testing.T) {
 		t.Fatal(fmt.Errorf("tx: invalid number of records %d - 1 expected", i))
 	}
 
-	//rollback insert
+	// rollback insert
 	if err := tx.Rollback(); err != nil {
 		t.Fatal(err)
 	}
 
-	//new transaction
+	// new transaction
 	tx, err = db.Begin()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer tx.Rollback()
 
-	//rollback - no record expected
+	// rollback - no record expected
 	if err := tx.QueryRow(fmt.Sprintf("select count(*) from %s", table)).Scan(&i); err != nil {
 		t.Fatal(err)
 	}

--- a/prometheus/collectors/example_test.go
+++ b/prometheus/collectors/example_test.go
@@ -61,19 +61,22 @@ func Example() {
 	// register collector for sql.DB stats.
 	sqlDBStatsCollector := collectors.NewDBStatsCollector(db.DB, dbName)
 	if err := prometheus.Register(sqlDBStatsCollector); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	// register collector for go-hdb driver stats.
 	driverCollector := drivercollectors.NewDriverStatsCollector(connector.NativeDriver(), dbName)
 	if err := prometheus.Register(driverCollector); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	// register collector for extended go-hdb db stats.
 	driverDBExStatsCollector := drivercollectors.NewDBExStatsCollector(db, dbName)
 	if err := prometheus.Register(driverDBExStatsCollector); err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
Hi @stfnmllr,

This fix some trivial issues reported by [go-critic](https://github.com/go-critic/go-critic).

The only one missing need to be checked more carefully. See,

```
golangci-lint run --disable-all --enable=gocritic ./...
driver/internal/protocol/fieldtype.go:385:2: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
        switch v := v.(type) {
        ^
```