### PR TITLE
Fix release version typo

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -5,7 +5,7 @@ Release Notes
 
 ### Minor revisions
 
-#### v1.0.8
+#### v1.0.9
 - upgraded dependencies
 
 #### v1.0.8


### PR DESCRIPTION
Hello.

I think there is a typo in the release note.

`v1.0.8` -> `v1.0.9`

Thanks !